### PR TITLE
there is too much risk parsing dates, just print them as they come

### DIFF
--- a/ckanext/sitemap/view.py
+++ b/ckanext/sitemap/view.py
@@ -75,8 +75,7 @@ def sitemap_controller():
             pkg_url = tk.url_for(controller="dataset", action="read", id=pkg["name"])
             loc.text = tk.config.get("ckan.site_url") + pkg_url
             lastmod = etree.SubElement(url, "lastmod")
-            metadata_modifiedDate = datetime.strptime(pkg["metadata_modified"], "%Y-%m-%dT%H:%M:%S.%f")
-            lastmod.text = metadata_modifiedDate.strftime("%Y-%m-%d")
+            lastmod.text = pkg["metadata_modified"]
             resources = list(pkg["resources"])
 
             for res in resources:
@@ -90,10 +89,9 @@ def sitemap_controller():
                 )
                 lastmod = etree.SubElement(url, "lastmod")
                 if res["last_modified"]:
-                    resmodifiedDate = datetime.strptime(res["last_modified"], "%Y-%m-%dT%H:%M:%S.%f")
+                    lastmod.text = res["last_modified"]
                 else:
-                    resmodifiedDate = datetime.strptime(res["created"], "%Y-%m-%dT%H:%M:%S.%f")
-                lastmod.text = resmodifiedDate.strftime("%Y-%m-%d")
+                    lastmod.text = res["created"]
 
         with open(os.path.join(current_dir, filename), "wb") as f:
             f.write(etree.tostring(root, pretty_print=True))

--- a/ckanext/sitemap/view.py
+++ b/ckanext/sitemap/view.py
@@ -37,10 +37,10 @@ def sitemap_controller():
         context = {'model': model, 'session': model.Session, 'user': c.user or c.author}
         data_dict = {
             'q': '*:*',
-            'fq': 'dataset_type:dataset OR dataset_type:showcase',
+            'fq': 'dataset_type:dataset',
             'start': 0,
             'include_private': False,
-            'rows': 500  # Adjust as needed
+            'rows': 500
         }
 
         # Use the package_search action to query datasets
@@ -88,7 +88,7 @@ def sitemap_controller():
                     resource_id=res["id"]
                 )
                 lastmod = etree.SubElement(url, "lastmod")
-                if res["last_modified"]:
+                if res.get("last_modified"):
                     lastmod.text = res["last_modified"]
                 else:
                     lastmod.text = res["created"]


### PR DESCRIPTION
## [Addition of sitemap capabilities to Open Data](https://opengovinc.atlassian.net/browse/OD-2439)

## Description
* there is too much risk parsing dates, just print them as they come to avoid errors like "ValueError: time data '2017-10-13T00:00:00' does not match format '%Y-%m-%dT%H:%M:%S.%f'"
